### PR TITLE
docs: add samples from datacatalog

### DIFF
--- a/samples/snippets/cloud-client/README.rst
+++ b/samples/snippets/cloud-client/README.rst
@@ -1,0 +1,3 @@
+These samples have been moved.
+
+https://github.com/googleapis/python-datacatalog/tree/master/samples


### PR DESCRIPTION
Samples from https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/datacatalog