### PR TITLE
chore: add NLP team members to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 *               @googleapis/yoshi-python
 
 # The python-samples-reviewers team is the default owner for samples changes
-/samples/   @telpirion @sirtorry @googleapis/python-samples-owners
+/samples/   @telpirion @sirtorry @lucaswadedavis @googleapis/python-samples-owners


### PR DESCRIPTION
Adds lucaswadedavis@ as code owner for this repo.